### PR TITLE
Fix install command in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A [knockout](http://knockoutjs.com/) generator for [Yeoman](http://yeoman.io).
 ## Getting started
 - Make sure you have [yo](https://github.com/yeoman/yo) installed:
     `npm install -g yo`
-- Install the generator: `npm install -g generator-requirejs` *(locally works too)*
+- Install the generator: `npm install -g generator-knockout` *(locally works too)*
 - Run: `yo knockout`
 
 ## License


### PR DESCRIPTION
The current command installs `generator-requirejs`, i don't think thats intentional...
