### PR TITLE
Modified the value of files in watch:src task in Gruntfile.js

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -63,7 +63,7 @@ module.exports = function(grunt) {
         tasks: ['jshint:gruntfile']
       },
       src: {
-        files: '<%%= jshint.src.src %>',
+        files: '<%%= jshint.app.src %>',
         tasks: ['jshint:src', 'qunit']
       },
       test: {


### PR DESCRIPTION
Hi,

I tried generator-knockout with yo and added livereload by updating Gruntfile.js.

Then, I aware the following warning during "grunt preview".

Warning: An error occurred while processing a template (Cannot read property 'src' of undefined).
Warning: An error occurred while processing a template (Cannot read property 'src' of undefined).

I found the cause of this warning.
Could you review my commit for the issue? If it's OK, I appreciate if you apply my pull request.

Thank you.
